### PR TITLE
prevent panic when refs is nil

### DIFF
--- a/passes/sqlrows/sqlrows.go
+++ b/passes/sqlrows/sqlrows.go
@@ -91,11 +91,16 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				called, ok := sqlrowsutil.CalledFrom(b, i, rowsType, methods...)
 				if called {
 					var defered bool
-					for _, ref := range *refs {
-						if _, ok := ref.(*ssa.Defer); ok {
-							defered = true
+					if refs != nil {
+						for _, ref := range *refs {
+							if _, ok := ref.(*ssa.Defer); ok {
+								defered = true
+							}
 						}
+					} else {
+						pass.Reportf(pos, "*refs is nil for some reason. This line at least prevents a panic")
 					}
+
 					if !defered {
 						pass.Reportf(pos, "rows.Close must be called in defer function")
 					}


### PR DESCRIPTION
This PR prevents a panic when *refs is nil. I've no idea why it's nil. Sometimes it seems to get confused when the rows, err := assignment, error checking and the usage of rows.Next are far apart or somehow in a different block. Will check if I can improve the check some other day. At least this fix prevents from the whole tool crashing and not have any output at all.

Issue: #9 
